### PR TITLE
Do not use a null classloader

### DIFF
--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/storage/LogStoreProvider.scala
@@ -55,8 +55,13 @@ private[internal] trait LogStoreProvider {
       new DelegatingLogStore(hadoopConf)
     } else {
       // scalastyle:off classforname
+      // Do not pass a null class loader
+      // - https://github.com/netty/netty/issues/7290
+      // - https://bugs.openjdk.java.net/browse/JDK-7008595
+      val classLoader: java.lang.ClassLoader = Option(Thread.currentThread().getContextClassLoader)
+        .getOrElse(this.getClass().getClassLoader)
       val logStoreClass =
-        Class.forName(className, true, Thread.currentThread().getContextClassLoader)
+        Class.forName(className, true, classLoader)
       // scalastyle:on classforname
 
       if (classOf[LogStore].isAssignableFrom(logStoreClass)) {


### PR DESCRIPTION
Netty for example sets the thread class loaders to null to avoid memory leaks.  If the thread class loader is null use the current class loader.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
